### PR TITLE
fix M591_report - start loop at extruder[0] instead of extruder[1]

### DIFF
--- a/Marlin/src/gcode/feature/runout/M591.cpp
+++ b/Marlin/src/gcode/feature/runout/M591.cpp
@@ -83,7 +83,7 @@ void GcodeSuite::M591() {
 
 void GcodeSuite::M591_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, F(STR_FILAMENT_RUNOUT_SENSOR));
-  LOOP_S_L_N(e, 1, NUM_RUNOUT_SENSORS)
+  LOOP_S_L_N(e, 0, NUM_RUNOUT_SENSORS)
     SERIAL_ECHOLNPGM(
       "  M591"
       #if MULTI_FILAMENT_SENSOR


### PR DESCRIPTION
### Requirements

file M591.cpp
I propose setting the initial value of e on line 86 to `0` rather than `1` as it is now. The loop fails to ever run if e is initially set to 1. `for (uint8_t e=(1); e<(1); e++)` will never evaluate true.

### Description

When executing GcodeSuite::M591_report the loop never loops to report the status.

### Benefits

M503 will now report runout status

### Configurations

no configs necessary

### Related Issues

I'm not sure if it's a known issue, I just noticed it earlier today.
